### PR TITLE
merge v1.4.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 * Unreleased
+* 1.4.1 (2021-02-11)
+    * Simplify `binarySearchByKey()` by removing unnecessary `records`
+      parameter. The lambda expression `key` is sufficient.
+        * Technically, this is an API breaking change, technically I'm supposed
+          bump the minor version number. But the `binarySearchByKey()` feature
+          was released only 2 days ago, so let's treat this as a bug fix. In
+          other words, the function signature should have been this from the
+          beginning.
 * 1.4 (2021-02-09)
     * Add `binarySearch()` and `binarySearchByKey()` templatized functions.
     * Explicitly blacklist megaAVR and SAMD21 using `arduino:samd>=1.8.10`

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ automatically:
     * `size_t binarySearch(const X list[], size_t size, const X& x)`
     * Templatized binary search of array of records or array of elements.
 
-**Version**: 1.4 (2021-02-09)
+**Version**: 1.4.1 (2021-02-11)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ automatically:
     * `class KString`
 * [src/algorithms/binarySearch.h](src/algorithms/binarySearch.h)
     * [src/algorithms/README.md](src/algorithms/README.md)
-    * `size_t binarySearchByKey(const R records[],
-      size_t size, const X& x, K&& key)`
+    * `size_t binarySearchByKey(size_t size, const X& x, K&& key)`
     * `size_t binarySearch(const X list[], size_t size, const X& x)`
     * Templatized binary search of array of records or array of elements.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Documentation
+
+These [Doxygen docs](https://bxparks.github.io/AceCommon/html/) are
+viewable on GitHub Pages.

--- a/docs/doxygen.cfg
+++ b/docs/doxygen.cfg
@@ -38,7 +38,7 @@ PROJECT_NAME           = "AceCommon"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.4
+PROJECT_NUMBER         = 1.4.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/html/AceCommon_8h_source.html
+++ b/docs/html/AceCommon_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>
@@ -120,8 +120,8 @@ $(function() {
 <div class="line"><a name="l00058"></a><span class="lineno">   58</span>&#160;<span class="preprocessor">#include &quot;<a class="code" href="binarySearch_8h.html">algorithms/binarySearch.h</a>&quot;</span></div>
 <div class="line"><a name="l00059"></a><span class="lineno">   59</span>&#160; </div>
 <div class="line"><a name="l00060"></a><span class="lineno">   60</span>&#160;<span class="comment">// Version format: &quot;xx.yy.zz&quot; =&gt; xxyyzz (without leading 0)</span></div>
-<div class="line"><a name="l00061"></a><span class="lineno">   61</span>&#160;<span class="preprocessor">#define ACE_COMMON_VERSION 10400</span></div>
-<div class="line"><a name="l00062"></a><span class="lineno">   62</span>&#160;<span class="preprocessor">#define ACE_COMMON_VERSION_STRING &quot;1.4&quot;</span></div>
+<div class="line"><a name="l00061"></a><span class="lineno">   61</span>&#160;<span class="preprocessor">#define ACE_COMMON_VERSION 10401</span></div>
+<div class="line"><a name="l00062"></a><span class="lineno">   62</span>&#160;<span class="preprocessor">#define ACE_COMMON_VERSION_STRING &quot;1.4.1&quot;</span></div>
 <div class="line"><a name="l00063"></a><span class="lineno">   63</span>&#160; </div>
 <div class="line"><a name="l00064"></a><span class="lineno">   64</span>&#160;<span class="preprocessor">#endif</span></div>
 </div><!-- fragment --></div><!-- contents -->

--- a/docs/html/FCString_8cpp_source.html
+++ b/docs/html/FCString_8cpp_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/FCString_8h_source.html
+++ b/docs/html/FCString_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/KString_8cpp_source.html
+++ b/docs/html/KString_8cpp_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/KString_8h_source.html
+++ b/docs/html/KString_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/PrintStr_8h_source.html
+++ b/docs/html/PrintStr_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/TimingStats_8h_source.html
+++ b/docs/html/TimingStats_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/annotated.html
+++ b/docs/html/annotated.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/arithmetic_8h.html
+++ b/docs/html/arithmetic_8h.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/arithmetic_8h_source.html
+++ b/docs/html/arithmetic_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/binarySearch_8h.html
+++ b/docs/html/binarySearch_8h.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>
@@ -97,14 +97,14 @@ This graph shows which files directly or indirectly include this file:</div>
 <table class="memberdecls">
 <tr class="heading"><td colspan="2"><h2 class="groupheader"><a name="func-members"></a>
 Functions</h2></td></tr>
-<tr class="memitem:a284143acfd437ee8867a338213ed0044"><td class="memTemplParams" colspan="2">template&lt;typename R , typename X , typename K &gt; </td></tr>
-<tr class="memitem:a284143acfd437ee8867a338213ed0044"><td class="memTemplItemLeft" align="right" valign="top">size_t&#160;</td><td class="memTemplItemRight" valign="bottom"><a class="el" href="binarySearch_8h.html#a284143acfd437ee8867a338213ed0044">ace_common::binarySearchByKey</a> (const R records[], size_t size, const X &amp;x, K &amp;&amp;key)</td></tr>
-<tr class="memdesc:a284143acfd437ee8867a338213ed0044"><td class="mdescLeft">&#160;</td><td class="mdescRight">Perform a binary search on the 'records' array of given 'size', which is sorted by the 'key', looking for element 'x' that matches the 'key'.  <a href="binarySearch_8h.html#a284143acfd437ee8867a338213ed0044">More...</a><br /></td></tr>
-<tr class="separator:a284143acfd437ee8867a338213ed0044"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:aac7eb6c55d8decc16875445b330ec8d6"><td class="memTemplParams" colspan="2">template&lt;typename X , typename K &gt; </td></tr>
+<tr class="memitem:aac7eb6c55d8decc16875445b330ec8d6"><td class="memTemplItemLeft" align="right" valign="top">size_t&#160;</td><td class="memTemplItemRight" valign="bottom"><a class="el" href="binarySearch_8h.html#aac7eb6c55d8decc16875445b330ec8d6">ace_common::binarySearchByKey</a> (size_t size, const X &amp;x, K &amp;&amp;key)</td></tr>
+<tr class="memdesc:aac7eb6c55d8decc16875445b330ec8d6"><td class="mdescLeft">&#160;</td><td class="mdescRight">Perform a binary search for element 'x' on an abstract list of records which are sorted by the 'key'.  <a href="binarySearch_8h.html#aac7eb6c55d8decc16875445b330ec8d6">More...</a><br /></td></tr>
+<tr class="separator:aac7eb6c55d8decc16875445b330ec8d6"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:abe3003dd71c6e85b71e7e7f0456c1acb"><td class="memTemplParams" colspan="2"><a id="abe3003dd71c6e85b71e7e7f0456c1acb"></a>
 template&lt;typename X &gt; </td></tr>
 <tr class="memitem:abe3003dd71c6e85b71e7e7f0456c1acb"><td class="memTemplItemLeft" align="right" valign="top">size_t&#160;</td><td class="memTemplItemRight" valign="bottom"><a class="el" href="binarySearch_8h.html#abe3003dd71c6e85b71e7e7f0456c1acb">ace_common::binarySearch</a> (const X list[], size_t size, const X &amp;x)</td></tr>
-<tr class="memdesc:abe3003dd71c6e85b71e7e7f0456c1acb"><td class="mdescLeft">&#160;</td><td class="mdescRight">Simplified version of <a class="el" href="binarySearch_8h.html#a284143acfd437ee8867a338213ed0044" title="Perform a binary search on the &#39;records&#39; array of given &#39;size&#39;, which is sorted by the &#39;key&#39;,...">binarySearchByKey()</a> where R and X are identical so the 'key' lambda expression just returns the value of the 'list[i]'. <br /></td></tr>
+<tr class="memdesc:abe3003dd71c6e85b71e7e7f0456c1acb"><td class="mdescLeft">&#160;</td><td class="mdescRight">Simplified version of <a class="el" href="binarySearch_8h.html#aac7eb6c55d8decc16875445b330ec8d6" title="Perform a binary search for element &#39;x&#39; on an abstract list of records which are sorted by the &#39;key&#39;.">binarySearchByKey()</a> where R and X are identical so the 'key' lambda expression just returns the value of the 'list[i]'. <br /></td></tr>
 <tr class="separator:abe3003dd71c6e85b71e7e7f0456c1acb"><td class="memSeparator" colspan="2">&#160;</td></tr>
 </table>
 <a name="details" id="details"></a><h2 class="groupheader">Detailed Description</h2>
@@ -115,23 +115,17 @@ template&lt;typename X &gt; </td></tr>
 
 <p class="definition">Definition in file <a class="el" href="binarySearch_8h_source.html">binarySearch.h</a>.</p>
 </div><h2 class="groupheader">Function Documentation</h2>
-<a id="a284143acfd437ee8867a338213ed0044"></a>
-<h2 class="memtitle"><span class="permalink"><a href="#a284143acfd437ee8867a338213ed0044">&#9670;&nbsp;</a></span>binarySearchByKey()</h2>
+<a id="aac7eb6c55d8decc16875445b330ec8d6"></a>
+<h2 class="memtitle"><span class="permalink"><a href="#aac7eb6c55d8decc16875445b330ec8d6">&#9670;&nbsp;</a></span>binarySearchByKey()</h2>
 
 <div class="memitem">
 <div class="memproto">
 <div class="memtemplate">
-template&lt;typename R , typename X , typename K &gt; </div>
+template&lt;typename X , typename K &gt; </div>
       <table class="memname">
         <tr>
           <td class="memname">size_t ace_common::binarySearchByKey </td>
           <td>(</td>
-          <td class="paramtype">const R&#160;</td>
-          <td class="paramname"><em>records</em>[], </td>
-        </tr>
-        <tr>
-          <td class="paramkey"></td>
-          <td></td>
           <td class="paramtype">size_t&#160;</td>
           <td class="paramname"><em>size</em>, </td>
         </tr>
@@ -155,12 +149,12 @@ template&lt;typename R , typename X , typename K &gt; </div>
       </table>
 </div><div class="memdoc">
 
-<p>Perform a binary search on the 'records' array of given 'size', which is sorted by the 'key', looking for element 'x' that matches the 'key'. </p>
-<p>The 'key' is a function or lambda expression to retrieve the value of 'X' at index 'i'.</p>
-<p>Return the index offset if found. Return SIZE_MAX if not found. SIZE_MAX can never be a valid return value because the largest value for 'size' is SIZE_MAX, which means that largest valid index is 'SIZE_MAX - 1'. Therefore, we can use SIZE_MAX to indicate the 'not found' condition.</p>
+<p>Perform a binary search for element 'x' on an abstract list of records which are sorted by the 'key'. </p>
+<p>The 'key' is a function or lambda expression that retrieves the value of 'X' at index 'i' in the records.</p>
+<p>Note that the list of 'records' does <em>not</em> need to be given to this function, because the required information is provided by the 'key' which maps the index 'i' to the element of type 'X'. The only extra bit of information needed is the 'size' of the list of records.</p>
+<p>Returns the index offset if found. Returns SIZE_MAX if not found. SIZE_MAX can never be a valid return value because the largest value for 'size' is SIZE_MAX, which means that largest valid index is 'SIZE_MAX - 1'. Therefore, we can use SIZE_MAX to indicate the 'not found' condition.</p>
 <dl class="tparams"><dt>Template Parameters</dt><dd>
   <table class="tparams">
-    <tr><td class="paramname">R</td><td>type of each element in records </td></tr>
     <tr><td class="paramname">X</td><td>type of element to look for, assumed to be cheap to copy (e.g. a primitive type like an 'int' or 'uint32_t') </td></tr>
     <tr><td class="paramname">K</td><td>lambda expression or function pointer that returns the 'X' value at index 'i'</td></tr>
   </table>
@@ -168,8 +162,7 @@ template&lt;typename R , typename X , typename K &gt; </div>
 </dl>
 <dl class="params"><dt>Parameters</dt><dd>
   <table class="params">
-    <tr><td class="paramname">records</td><td>an ordered records of R </td></tr>
-    <tr><td class="paramname">size</td><td>size of elements in records </td></tr>
+    <tr><td class="paramname">size</td><td>number of elements in records </td></tr>
     <tr><td class="paramname">x</td><td>the element to look for </td></tr>
     <tr><td class="paramname">key</td><td>a function or lambda expression that returns the 'X' value at index 'i'. If the 'key' inlined, I think the compiler is smart enough to inline the 'key' into this code, and avoid a function call.</td></tr>
   </table>
@@ -179,7 +172,7 @@ template&lt;typename R , typename X , typename K &gt; </div>
 <p>If the 'records' is not sorted, the function will probably fail to find the element. I don't think it will go into an infinite loop, but I'm not sure.</p>
 <p>If there are duplicate elements, the function returns the first one that it finds. </p>
 
-<p class="definition">Definition at line <a class="el" href="binarySearch_8h_source.html#l00094">94</a> of file <a class="el" href="binarySearch_8h_source.html">binarySearch.h</a>.</p>
+<p class="definition">Definition at line <a class="el" href="binarySearch_8h_source.html#l00096">96</a> of file <a class="el" href="binarySearch_8h_source.html">binarySearch.h</a>.</p>
 
 </div>
 </div>

--- a/docs/html/binarySearch_8h_source.html
+++ b/docs/html/binarySearch_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>
@@ -102,45 +102,39 @@ $(function() {
 <div class="line"><a name="l00057"></a><span class="lineno">   57</span>&#160; </div>
 <div class="line"><a name="l00058"></a><span class="lineno">   58</span>&#160;<span class="keyword">namespace </span>ace_common {</div>
 <div class="line"><a name="l00059"></a><span class="lineno">   59</span>&#160; </div>
-<div class="line"><a name="l00093"></a><span class="lineno">   93</span>&#160;<span class="keyword">template</span>&lt;<span class="keyword">typename</span> R, <span class="keyword">typename</span> X, <span class="keyword">typename</span> K&gt;</div>
-<div class="line"><a name="l00094"></a><span class="lineno"><a class="line" href="binarySearch_8h.html#a284143acfd437ee8867a338213ed0044">   94</a></span>&#160;<span class="keywordtype">size_t</span> <a class="code" href="binarySearch_8h.html#a284143acfd437ee8867a338213ed0044">binarySearchByKey</a>(</div>
-<div class="line"><a name="l00095"></a><span class="lineno">   95</span>&#160;    <span class="keyword">const</span> R records[], <span class="comment">// supports both &#39;const R[N]&#39; and &#39;const R*&#39;</span></div>
-<div class="line"><a name="l00096"></a><span class="lineno">   96</span>&#160;    <span class="keywordtype">size_t</span> size,</div>
-<div class="line"><a name="l00097"></a><span class="lineno">   97</span>&#160;    <span class="keyword">const</span> X&amp; x,</div>
-<div class="line"><a name="l00098"></a><span class="lineno">   98</span>&#160;    K&amp;&amp; key</div>
-<div class="line"><a name="l00099"></a><span class="lineno">   99</span>&#160;) {</div>
-<div class="line"><a name="l00100"></a><span class="lineno">  100</span>&#160;  <span class="keywordtype">size_t</span> a = 0;</div>
-<div class="line"><a name="l00101"></a><span class="lineno">  101</span>&#160;  <span class="keywordtype">size_t</span> b = size;</div>
-<div class="line"><a name="l00102"></a><span class="lineno">  102</span>&#160;  <span class="keywordflow">while</span> (<span class="keyword">true</span>) {</div>
-<div class="line"><a name="l00103"></a><span class="lineno">  103</span>&#160;    <span class="keywordtype">size_t</span> diff = b - a;</div>
-<div class="line"><a name="l00104"></a><span class="lineno">  104</span>&#160;    <span class="keywordflow">if</span> (diff == 0) <span class="keywordflow">break</span>;</div>
-<div class="line"><a name="l00105"></a><span class="lineno">  105</span>&#160; </div>
-<div class="line"><a name="l00106"></a><span class="lineno">  106</span>&#160;    <span class="keywordtype">size_t</span> c = a + diff / 2;</div>
-<div class="line"><a name="l00107"></a><span class="lineno">  107</span>&#160;    X current = key(c);</div>
-<div class="line"><a name="l00108"></a><span class="lineno">  108</span>&#160;    <span class="keywordflow">if</span> (current == x) <span class="keywordflow">return</span> c;</div>
-<div class="line"><a name="l00109"></a><span class="lineno">  109</span>&#160;    <span class="keywordflow">if</span> (x &lt; current) {</div>
-<div class="line"><a name="l00110"></a><span class="lineno">  110</span>&#160;      b = c;</div>
-<div class="line"><a name="l00111"></a><span class="lineno">  111</span>&#160;    } <span class="keywordflow">else</span> {</div>
-<div class="line"><a name="l00112"></a><span class="lineno">  112</span>&#160;      a = c + 1;</div>
-<div class="line"><a name="l00113"></a><span class="lineno">  113</span>&#160;    }</div>
-<div class="line"><a name="l00114"></a><span class="lineno">  114</span>&#160;  }</div>
-<div class="line"><a name="l00115"></a><span class="lineno">  115</span>&#160;  <span class="keywordflow">return</span> SIZE_MAX;</div>
-<div class="line"><a name="l00116"></a><span class="lineno">  116</span>&#160;}</div>
-<div class="line"><a name="l00117"></a><span class="lineno">  117</span>&#160; </div>
-<div class="line"><a name="l00122"></a><span class="lineno">  122</span>&#160;<span class="keyword">template</span>&lt;<span class="keyword">typename</span> X&gt;</div>
-<div class="line"><a name="l00123"></a><span class="lineno"><a class="line" href="binarySearch_8h.html#abe3003dd71c6e85b71e7e7f0456c1acb">  123</a></span>&#160;<span class="keywordtype">size_t</span> <a class="code" href="binarySearch_8h.html#abe3003dd71c6e85b71e7e7f0456c1acb">binarySearch</a>(<span class="keyword">const</span> X list[], <span class="keywordtype">size_t</span> size, <span class="keyword">const</span> X&amp; x) {</div>
-<div class="line"><a name="l00124"></a><span class="lineno">  124</span>&#160;  <span class="keywordflow">return</span> <a class="code" href="binarySearch_8h.html#a284143acfd437ee8867a338213ed0044">binarySearchByKey</a>(</div>
-<div class="line"><a name="l00125"></a><span class="lineno">  125</span>&#160;      list, size, x,</div>
-<div class="line"><a name="l00126"></a><span class="lineno">  126</span>&#160;      [&amp;list](<span class="keywordtype">size_t</span> i) { <span class="keywordflow">return</span> list[i]; } <span class="comment">/*key*/</span></div>
-<div class="line"><a name="l00127"></a><span class="lineno">  127</span>&#160;  );</div>
-<div class="line"><a name="l00128"></a><span class="lineno">  128</span>&#160;}</div>
-<div class="line"><a name="l00129"></a><span class="lineno">  129</span>&#160; </div>
-<div class="line"><a name="l00130"></a><span class="lineno">  130</span>&#160;} <span class="comment">// ace_common</span></div>
-<div class="line"><a name="l00131"></a><span class="lineno">  131</span>&#160; </div>
-<div class="line"><a name="l00132"></a><span class="lineno">  132</span>&#160;<span class="preprocessor">#endif</span></div>
+<div class="line"><a name="l00095"></a><span class="lineno">   95</span>&#160;<span class="keyword">template</span>&lt;<span class="keyword">typename</span> X, <span class="keyword">typename</span> K&gt;</div>
+<div class="line"><a name="l00096"></a><span class="lineno"><a class="line" href="binarySearch_8h.html#aac7eb6c55d8decc16875445b330ec8d6">   96</a></span>&#160;<span class="keywordtype">size_t</span> <a class="code" href="binarySearch_8h.html#aac7eb6c55d8decc16875445b330ec8d6">binarySearchByKey</a>(<span class="keywordtype">size_t</span> size, <span class="keyword">const</span> X&amp; x, K&amp;&amp; key) {</div>
+<div class="line"><a name="l00097"></a><span class="lineno">   97</span>&#160;  <span class="keywordtype">size_t</span> a = 0;</div>
+<div class="line"><a name="l00098"></a><span class="lineno">   98</span>&#160;  <span class="keywordtype">size_t</span> b = size;</div>
+<div class="line"><a name="l00099"></a><span class="lineno">   99</span>&#160;  <span class="keywordflow">while</span> (<span class="keyword">true</span>) {</div>
+<div class="line"><a name="l00100"></a><span class="lineno">  100</span>&#160;    <span class="keywordtype">size_t</span> diff = b - a;</div>
+<div class="line"><a name="l00101"></a><span class="lineno">  101</span>&#160;    <span class="keywordflow">if</span> (diff == 0) <span class="keywordflow">break</span>;</div>
+<div class="line"><a name="l00102"></a><span class="lineno">  102</span>&#160; </div>
+<div class="line"><a name="l00103"></a><span class="lineno">  103</span>&#160;    <span class="keywordtype">size_t</span> c = a + diff / 2;</div>
+<div class="line"><a name="l00104"></a><span class="lineno">  104</span>&#160;    X current = key(c);</div>
+<div class="line"><a name="l00105"></a><span class="lineno">  105</span>&#160;    <span class="keywordflow">if</span> (current == x) <span class="keywordflow">return</span> c;</div>
+<div class="line"><a name="l00106"></a><span class="lineno">  106</span>&#160;    <span class="keywordflow">if</span> (x &lt; current) {</div>
+<div class="line"><a name="l00107"></a><span class="lineno">  107</span>&#160;      b = c;</div>
+<div class="line"><a name="l00108"></a><span class="lineno">  108</span>&#160;    } <span class="keywordflow">else</span> {</div>
+<div class="line"><a name="l00109"></a><span class="lineno">  109</span>&#160;      a = c + 1;</div>
+<div class="line"><a name="l00110"></a><span class="lineno">  110</span>&#160;    }</div>
+<div class="line"><a name="l00111"></a><span class="lineno">  111</span>&#160;  }</div>
+<div class="line"><a name="l00112"></a><span class="lineno">  112</span>&#160;  <span class="keywordflow">return</span> SIZE_MAX;</div>
+<div class="line"><a name="l00113"></a><span class="lineno">  113</span>&#160;}</div>
+<div class="line"><a name="l00114"></a><span class="lineno">  114</span>&#160; </div>
+<div class="line"><a name="l00119"></a><span class="lineno">  119</span>&#160;<span class="keyword">template</span>&lt;<span class="keyword">typename</span> X&gt;</div>
+<div class="line"><a name="l00120"></a><span class="lineno"><a class="line" href="binarySearch_8h.html#abe3003dd71c6e85b71e7e7f0456c1acb">  120</a></span>&#160;<span class="keywordtype">size_t</span> <a class="code" href="binarySearch_8h.html#abe3003dd71c6e85b71e7e7f0456c1acb">binarySearch</a>(<span class="keyword">const</span> X list[], <span class="keywordtype">size_t</span> size, <span class="keyword">const</span> X&amp; x) {</div>
+<div class="line"><a name="l00121"></a><span class="lineno">  121</span>&#160;  <span class="comment">// Note that &#39;const X list[]&#39; accepts &#39;const X*&#39; as well.</span></div>
+<div class="line"><a name="l00122"></a><span class="lineno">  122</span>&#160;  <span class="keywordflow">return</span> <a class="code" href="binarySearch_8h.html#aac7eb6c55d8decc16875445b330ec8d6">binarySearchByKey</a>(size, x,</div>
+<div class="line"><a name="l00123"></a><span class="lineno">  123</span>&#160;      [&amp;list](<span class="keywordtype">size_t</span> i) { <span class="keywordflow">return</span> list[i]; } <span class="comment">/*key*/</span>);</div>
+<div class="line"><a name="l00124"></a><span class="lineno">  124</span>&#160;}</div>
+<div class="line"><a name="l00125"></a><span class="lineno">  125</span>&#160; </div>
+<div class="line"><a name="l00126"></a><span class="lineno">  126</span>&#160;} <span class="comment">// ace_common</span></div>
+<div class="line"><a name="l00127"></a><span class="lineno">  127</span>&#160; </div>
+<div class="line"><a name="l00128"></a><span class="lineno">  128</span>&#160;<span class="preprocessor">#endif</span></div>
 </div><!-- fragment --></div><!-- contents -->
-<div class="ttc" id="abinarySearch_8h_html_abe3003dd71c6e85b71e7e7f0456c1acb"><div class="ttname"><a href="binarySearch_8h.html#abe3003dd71c6e85b71e7e7f0456c1acb">ace_common::binarySearch</a></div><div class="ttdeci">size_t binarySearch(const X list[], size_t size, const X &amp;x)</div><div class="ttdoc">Simplified version of binarySearchByKey() where R and X are identical so the 'key' lambda expression ...</div><div class="ttdef"><b>Definition:</b> <a href="binarySearch_8h_source.html#l00123">binarySearch.h:123</a></div></div>
-<div class="ttc" id="abinarySearch_8h_html_a284143acfd437ee8867a338213ed0044"><div class="ttname"><a href="binarySearch_8h.html#a284143acfd437ee8867a338213ed0044">ace_common::binarySearchByKey</a></div><div class="ttdeci">size_t binarySearchByKey(const R records[], size_t size, const X &amp;x, K &amp;&amp;key)</div><div class="ttdoc">Perform a binary search on the 'records' array of given 'size', which is sorted by the 'key',...</div><div class="ttdef"><b>Definition:</b> <a href="binarySearch_8h_source.html#l00094">binarySearch.h:94</a></div></div>
+<div class="ttc" id="abinarySearch_8h_html_abe3003dd71c6e85b71e7e7f0456c1acb"><div class="ttname"><a href="binarySearch_8h.html#abe3003dd71c6e85b71e7e7f0456c1acb">ace_common::binarySearch</a></div><div class="ttdeci">size_t binarySearch(const X list[], size_t size, const X &amp;x)</div><div class="ttdoc">Simplified version of binarySearchByKey() where R and X are identical so the 'key' lambda expression ...</div><div class="ttdef"><b>Definition:</b> <a href="binarySearch_8h_source.html#l00120">binarySearch.h:120</a></div></div>
+<div class="ttc" id="abinarySearch_8h_html_aac7eb6c55d8decc16875445b330ec8d6"><div class="ttname"><a href="binarySearch_8h.html#aac7eb6c55d8decc16875445b330ec8d6">ace_common::binarySearchByKey</a></div><div class="ttdeci">size_t binarySearchByKey(size_t size, const X &amp;x, K &amp;&amp;key)</div><div class="ttdoc">Perform a binary search for element 'x' on an abstract list of records which are sorted by the 'key'.</div><div class="ttdef"><b>Definition:</b> <a href="binarySearch_8h_source.html#l00096">binarySearch.h:96</a></div></div>
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
 Generated by &#160;<a href="http://www.doxygen.org/index.html">

--- a/docs/html/classace__common_1_1FCString-members.html
+++ b/docs/html/classace__common_1_1FCString-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classace__common_1_1FCString.html
+++ b/docs/html/classace__common_1_1FCString.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classace__common_1_1KString-members.html
+++ b/docs/html/classace__common_1_1KString-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classace__common_1_1KString.html
+++ b/docs/html/classace__common_1_1KString.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classace__common_1_1PrintStr-members.html
+++ b/docs/html/classace__common_1_1PrintStr-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classace__common_1_1PrintStr.html
+++ b/docs/html/classace__common_1_1PrintStr.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classace__common_1_1PrintStrBase-members.html
+++ b/docs/html/classace__common_1_1PrintStrBase-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classace__common_1_1PrintStrBase.html
+++ b/docs/html/classace__common_1_1PrintStrBase.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classace__common_1_1PrintStrN-members.html
+++ b/docs/html/classace__common_1_1PrintStrN-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classace__common_1_1PrintStrN.html
+++ b/docs/html/classace__common_1_1PrintStrN.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classace__common_1_1TimingStats-members.html
+++ b/docs/html/classace__common_1_1TimingStats-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classace__common_1_1TimingStats.html
+++ b/docs/html/classace__common_1_1TimingStats.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/classes.html
+++ b/docs/html/classes.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_000000_000001.html
+++ b/docs/html/dir_000000_000001.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_000000_000003.html
+++ b/docs/html/dir_000000_000003.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_000000_000005.html
+++ b/docs/html/dir_000000_000005.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_000000_000006.html
+++ b/docs/html/dir_000000_000006.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_000000_000008.html
+++ b/docs/html/dir_000000_000008.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_000000_000010.html
+++ b/docs/html/dir_000000_000010.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_076fa40de0c6d9cd6161de2487adf7ef.html
+++ b/docs/html/dir_076fa40de0c6d9cd6161de2487adf7ef.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_1fa5a6729de1942c7b583c1b69dc99ef.html
+++ b/docs/html/dir_1fa5a6729de1942c7b583c1b69dc99ef.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_556a0751f5b36f9dd0396d157cfaa160.html
+++ b/docs/html/dir_556a0751f5b36f9dd0396d157cfaa160.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_68267d1309a1af8e8297ef4c3efbcdba.html
+++ b/docs/html/dir_68267d1309a1af8e8297ef4c3efbcdba.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_81ff9cf00c749aad2228acad00958fb4.html
+++ b/docs/html/dir_81ff9cf00c749aad2228acad00958fb4.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_84e4b9a1ea05a12852c005a100594911.html
+++ b/docs/html/dir_84e4b9a1ea05a12852c005a100594911.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_c91538367e1cf31feb3023868ae68630.html
+++ b/docs/html/dir_c91538367e1cf31feb3023868ae68630.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_e6df591b0639d4c4807ef64d058833e2.html
+++ b/docs/html/dir_e6df591b0639d4c4807ef64d058833e2.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_f2ea210ba2f26c16cc197323cef401a4.html
+++ b/docs/html/dir_f2ea210ba2f26c16cc197323cef401a4.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_f4696761a9ed954a22cfd40726bbf184.html
+++ b/docs/html/dir_f4696761a9ed954a22cfd40726bbf184.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/dir_f5a0b06b07ceb1caa8ff4a009b8a344a.html
+++ b/docs/html/dir_f5a0b06b07ceb1caa8ff4a009b8a344a.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/djb2_8cpp_source.html
+++ b/docs/html/djb2_8cpp_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/djb2_8h.html
+++ b/docs/html/djb2_8h.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/djb2_8h_source.html
+++ b/docs/html/djb2_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/files.html
+++ b/docs/html/files.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/functions.html
+++ b/docs/html/functions.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/functions_func.html
+++ b/docs/html/functions_func.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/functions_vars.html
+++ b/docs/html/functions_vars.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/graph_legend.html
+++ b/docs/html/graph_legend.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/hierarchy.html
+++ b/docs/html/hierarchy.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/inherits.html
+++ b/docs/html/inherits.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/md__home_brian_src_AceCommon_src_algorithms_README.html
+++ b/docs/html/md__home_brian_src_AceCommon_src_algorithms_README.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>
@@ -73,14 +73,9 @@ $(function() {
 <div class="fragment"><div class="line"> {C++}</div>
 <div class="line">namespace ace_common {</div>
 <div class="line"> </div>
-<div class="line">// Binary search an array of records sorted by key.</div>
-<div class="line">template&lt;typename R, typename X, typename K&gt;</div>
-<div class="line">size_t binarySearchByKey(</div>
-<div class="line">    const R records[],</div>
-<div class="line">    size_t size,</div>
-<div class="line">    const X&amp; x,</div>
-<div class="line">    K&amp;&amp; key</div>
-<div class="line">);</div>
+<div class="line">// Binary search an (abstract) array of records sorted by key.</div>
+<div class="line">template&lt;typename X, typename K&gt;</div>
+<div class="line">size_t binarySearchByKey(size_t size, const X&amp; x, K&amp;&amp; key);</div>
 <div class="line"> </div>
 <div class="line">// Binary search a list of sorted elements.</div>
 <div class="line">template&lt;typename X&gt;</div>

--- a/docs/html/md__home_brian_src_AceCommon_src_print_str_README.html
+++ b/docs/html/md__home_brian_src_AceCommon_src_print_str_README.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/md__home_brian_src_AceCommon_src_print_utils_README.html
+++ b/docs/html/md__home_brian_src_AceCommon_src_print_utils_README.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/md__home_brian_src_AceCommon_src_timing_stats_README.html
+++ b/docs/html/md__home_brian_src_AceCommon_src_timing_stats_README.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/md__home_brian_src_AceCommon_src_url_encoding_README.html
+++ b/docs/html/md__home_brian_src_AceCommon_src_url_encoding_README.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/pages.html
+++ b/docs/html/pages.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/printPadTo_8h.html
+++ b/docs/html/printPadTo_8h.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/printPadTo_8h_source.html
+++ b/docs/html/printPadTo_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/printfTo_8h.html
+++ b/docs/html/printfTo_8h.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/printfTo_8h_source.html
+++ b/docs/html/printfTo_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/pstrings_8cpp_source.html
+++ b/docs/html/pstrings_8cpp_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/pstrings_8h.html
+++ b/docs/html/pstrings_8h.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/pstrings_8h_source.html
+++ b/docs/html/pstrings_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/search/all_1.js
+++ b/docs/html/search/all_1.js
@@ -3,6 +3,6 @@ var searchData=
   ['bcdtodec_3',['bcdToDec',['../arithmetic_8h.html#a8547966ab0e711d97251ab6cb074e181',1,'ace_common']]],
   ['binarysearch_4',['binarySearch',['../binarySearch_8h.html#abe3003dd71c6e85b71e7e7f0456c1acb',1,'ace_common']]],
   ['binarysearch_2eh_5',['binarySearch.h',['../binarySearch_8h.html',1,'']]],
-  ['binarysearchbykey_6',['binarySearchByKey',['../binarySearch_8h.html#a284143acfd437ee8867a338213ed0044',1,'ace_common']]],
+  ['binarysearchbykey_6',['binarySearchByKey',['../binarySearch_8h.html#aac7eb6c55d8decc16875445b330ec8d6',1,'ace_common']]],
   ['buf_5f_7',['buf_',['../classace__common_1_1PrintStrBase.html#a0b8ea388f529134fdfc0cde78d866b9a',1,'ace_common::PrintStrBase']]]
 ];

--- a/docs/html/search/functions_0.js
+++ b/docs/html/search/functions_0.js
@@ -2,5 +2,5 @@ var searchData=
 [
   ['bcdtodec_69',['bcdToDec',['../arithmetic_8h.html#a8547966ab0e711d97251ab6cb074e181',1,'ace_common']]],
   ['binarysearch_70',['binarySearch',['../binarySearch_8h.html#abe3003dd71c6e85b71e7e7f0456c1acb',1,'ace_common']]],
-  ['binarysearchbykey_71',['binarySearchByKey',['../binarySearch_8h.html#a284143acfd437ee8867a338213ed0044',1,'ace_common']]]
+  ['binarysearchbykey_71',['binarySearchByKey',['../binarySearch_8h.html#aac7eb6c55d8decc16875445b330ec8d6',1,'ace_common']]]
 ];

--- a/docs/html/url__encoding_8cpp_source.html
+++ b/docs/html/url__encoding_8cpp_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/url__encoding_8h.html
+++ b/docs/html/url__encoding_8h.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/docs/html/url__encoding_8h_source.html
+++ b/docs/html/url__encoding_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceCommon
-   &#160;<span id="projectnumber">1.4</span>
+   &#160;<span id="projectnumber">1.4.1</span>
    </div>
    <div id="projectbrief">Arduino library for low-level common functions and features with no external dependencies</div>
   </td>

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AceCommon
-version=1.4
+version=1.4.1
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=Small low-level classes and functions with no external dependencies so that they can be easily reused in other libraries.

--- a/src/AceCommon.h
+++ b/src/AceCommon.h
@@ -58,7 +58,7 @@ SOFTWARE.
 #include "algorithms/binarySearch.h"
 
 // Version format: "xx.yy.zz" => xxyyzz (without leading 0)
-#define ACE_COMMON_VERSION 10400
-#define ACE_COMMON_VERSION_STRING "1.4"
+#define ACE_COMMON_VERSION 10401
+#define ACE_COMMON_VERSION_STRING "1.4.1"
 
 #endif

--- a/src/algorithms/README.md
+++ b/src/algorithms/README.md
@@ -12,14 +12,9 @@ records.
 ```C++
 namespace ace_common {
 
-// Binary search an array of records sorted by key.
-template<typename R, typename X, typename K>
-size_t binarySearchByKey(
-    const R records[],
-    size_t size,
-    const X& x,
-    K&& key
-);
+// Binary search an (abstract) array of records sorted by key.
+template<typename X, typename K>
+size_t binarySearchByKey(size_t size, const X& x, K&& key);
 
 // Binary search a list of sorted elements.
 template<typename X>

--- a/src/algorithms/binarySearch.h
+++ b/src/algorithms/binarySearch.h
@@ -58,24 +58,26 @@ SOFTWARE.
 namespace ace_common {
 
 /**
- * Perform a binary search on the 'records' array of given 'size', which is
- * sorted by the 'key', looking for element 'x' that matches the 'key'. The
- * 'key' is a function or lambda expression to retrieve the value of 'X' at
- * index 'i'.
+ * Perform a binary search for element 'x' on an abstract list of records which
+ * are sorted by the 'key'. The 'key' is a function or lambda expression that
+ * retrieves the value of 'X' at index 'i' in the records.
  *
- * Return the index offset if found. Return SIZE_MAX if not found. SIZE_MAX can
- * never be a valid return value because the largest value for 'size' is
+ * Note that the list of 'records' does *not* need to be given to this
+ * function, because the required information is provided by the 'key' which
+ * maps the index 'i' to the element of type 'X'. The only extra bit of
+ * information needed is the 'size' of the list of records.
+ *
+ * Returns the index offset if found. Returns SIZE_MAX if not found. SIZE_MAX
+ * can never be a valid return value because the largest value for 'size' is
  * SIZE_MAX, which means that largest valid index is 'SIZE_MAX - 1'. Therefore,
  * we can use SIZE_MAX to indicate the 'not found' condition.
  *
- * @tparam R type of each element in records
  * @tparam X type of element to look for, assumed to be cheap to copy (e.g. a
  *    primitive type like an 'int' or 'uint32_t')
  * @tparam K lambda expression or function pointer that returns the 'X' value
  *    at index 'i'
  *
- * @param records an ordered records of R
- * @param size size of elements in records
+ * @param size number of elements in records
  * @param x the element to look for
  * @param key a function or lambda expression that returns the 'X' value
  *    at index 'i'. If the 'key' inlined, I think the compiler is smart
@@ -90,13 +92,8 @@ namespace ace_common {
  * If there are duplicate elements, the function returns the first one that it
  * finds.
  */
-template<typename R, typename X, typename K>
-size_t binarySearchByKey(
-    const R records[], // supports both 'const R[N]' and 'const R*'
-    size_t size,
-    const X& x,
-    K&& key
-) {
+template<typename X, typename K>
+size_t binarySearchByKey(size_t size, const X& x, K&& key) {
   size_t a = 0;
   size_t b = size;
   while (true) {
@@ -121,10 +118,9 @@ size_t binarySearchByKey(
  */
 template<typename X>
 size_t binarySearch(const X list[], size_t size, const X& x) {
-  return binarySearchByKey(
-      list, size, x,
-      [&list](size_t i) { return list[i]; } /*key*/
-  );
+  // Note that 'const X list[]' accepts 'const X*' as well.
+  return binarySearchByKey(size, x,
+      [&list](size_t i) { return list[i]; } /*key*/);
 }
 
 } // ace_common

--- a/tests/BinarySearchTest/BinarySearchTest.ino
+++ b/tests/BinarySearchTest/BinarySearchTest.ino
@@ -74,22 +74,20 @@ inline int key(size_t i) { return RECORDS[i].b; }
 
 // Test binary search by key using a function.
 test(binarySearchTest, records_with_function) {
-  assertEqual(SIZE_MAX, binarySearchByKey(RECORDS, NUM_RECORDS, 0, key));
-  assertEqual((size_t) 0, binarySearchByKey(RECORDS, NUM_RECORDS, 2, key));
-  assertEqual((size_t) 1, binarySearchByKey(RECORDS, NUM_RECORDS, 4, key));
-  assertEqual(SIZE_MAX, binarySearchByKey(RECORDS, NUM_RECORDS, 5, key));
-  assertEqual((size_t) 2, binarySearchByKey(RECORDS, NUM_RECORDS, 6, key));
-  assertEqual((size_t) 3, binarySearchByKey(RECORDS, NUM_RECORDS, 8, key));
+  assertEqual(SIZE_MAX, binarySearchByKey(NUM_RECORDS, 0, key));
+  assertEqual((size_t) 0, binarySearchByKey(NUM_RECORDS, 2, key));
+  assertEqual((size_t) 1, binarySearchByKey(NUM_RECORDS, 4, key));
+  assertEqual(SIZE_MAX, binarySearchByKey(NUM_RECORDS, 5, key));
+  assertEqual((size_t) 2, binarySearchByKey(NUM_RECORDS, 6, key));
+  assertEqual((size_t) 3, binarySearchByKey(NUM_RECORDS, 8, key));
 }
 
 // Test binary search by key using inlined lambda expression.
 test(binarySearchTest, records_with_lambda) {
   assertEqual(
       SIZE_MAX,
-      binarySearchByKey(
-          RECORDS, NUM_RECORDS, 10,
-          [](size_t i) { return RECORDS[i].b; } /*key*/
-      )
+      binarySearchByKey(NUM_RECORDS, 10,
+          [](size_t i) { return RECORDS[i].b; } /*key*/)
   );
 }
 


### PR DESCRIPTION
* 1.4.1 (2021-02-11)
    * Simplify `binarySearchByKey()` by removing unnecessary `records`
      parameter. The lambda expression `key` is sufficient.
        * Technically, this is an API breaking change, technically I'm supposed
          bump the minor version number. But the `binarySearchByKey()` feature
          was released only 2 days ago, so let's treat this as a bug fix. In
          other words, the function signature should have been this from the
          beginning.
