### PR TITLE
Add fix for override macro check on ESP32 atm

### DIFF
--- a/src/print_str/PrintStr.h
+++ b/src/print_str/PrintStr.h
@@ -121,7 +121,8 @@ class PrintStrBase: public Print {
       || defined(ARDUINO_AVR_ATTINYX5) \
       || defined(ARDUINO_AVR_ATTINYX61) \
       || defined(ARDUINO_AVR_ATTINYX7) \
-      || defined(ARDUINO_AVR_ATTINYX8)
+      || defined(ARDUINO_AVR_ATTINYX8) \
+      || defined(ARDUINO_ARCH_ESP32)
     void flush() {
   #else
     void flush() override {

--- a/src/print_str/PrintStr.h
+++ b/src/print_str/PrintStr.h
@@ -122,7 +122,7 @@ class PrintStrBase: public Print {
       || defined(ARDUINO_AVR_ATTINYX61) \
       || defined(ARDUINO_AVR_ATTINYX7) \
       || defined(ARDUINO_AVR_ATTINYX8) \
-      || defined(ARDUINO_ARCH_ESP32)
+      || (defined(ARDUINO_ARCH_ESP32) && defined(PLATFORMIO)) // hack because PIO is on espresif32 platform <v2.0.3
     void flush() {
   #else
     void flush() override {


### PR DESCRIPTION
Appears to fix this issue: https://github.com/bxparks/AceTime/issues/114

Perhaps there's a better solution to use though