### PR TITLE
merge 1.6.2 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
 * Unreleased
+* 1.6.2 (2023-06-25)
     * Add `tstrings.h` which adds various `strxxx_T()` overloaded functions
       which take either a `const char*` or a `const __FlashStringHelper*`
       parameter.
         * Allows writing C++ template code which is agnostic to whether the
           string argument is in normal memory or flash memory. The compiler will
           select the specific implementation automatically at compile-time.
+    * `PrintStr.h`
+        * Add special exception for ESP32 on PlatformIO which seems to be
+          stuck using the ESP32 Core from 1.x, which means that its
+          `Print::flush()` is non-virtual instead of virtual (fixed in v2.0.3).
+        * See [PR#28](https://github.com/bxparks/AceCommon/pull/28).
 * 1.6.1 (2023-06-09)
     * Fix backwards compatibility breakage in `KString()` constructor.
         * v1.5.2 supported only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 * Unreleased
+    * Add `tstrings.h` which adds various `strxxx_T()` overloaded functions
+      which take either a `const char*` or a `const __FlashStringHelper*`
+      parameter.
+        * Allows writing C++ template code which is agnostic to whether the
+          string argument is in normal memory or flash memory. The compiler will
+          select the specific implementation automatically at compile-time.
 * 1.6.1 (2023-06-09)
     * Fix backwards compatibility breakage in `KString()` constructor.
         * v1.5.2 supported only:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ automatically:
     * `int strcmp_PP(const char* a, const char* b)`
     * `const char* strchr_P(const char* s, char c)` (ESP8266 and ESP32 only)
     * `const char* strrchr_P(const char* s, char c)` (ESP8266 and ESP32 only)
+* [src/tstrings/tstrings.h](src/tstrings/tstrings.h)
+    * Overloaded functions which provide a thin layer of indirection around a
+      `const char*` or a `const __FlashStringHelper*`.
+    * Allows writing of template code which is agnostic to whether the string
+      is stored in normal memory or flash memory. The compiler will choose the
+      exact implementation at compile-time.
+    * `strcat_T()`
+    * `strchr_T()`
+    * `strcmp_()`
+    * `strcpy_T()`
+    * `strlen_T()`
+    * `strncat_T()`
+    * `strncmp_T()`
+    * `strncpy_T()`
+    * `strrchr_T()`
 * [src/fstrings/FCString.h](src/fstrings/FCString.h)
     * `class FCString`
     * An object that can hold either a C-string (`const char*`) or an

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ automatically:
     * [src/algorithms/README.md](src/algorithms/README.md)
     * `void reverse(T data[], size_t size)`
 
-**Version**: 1.6.1 (2023-06-09)
+**Version**: 1.6.2 (2023-06-25)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ automatically:
       exact implementation at compile-time.
     * `strcat_T()`
     * `strchr_T()`
-    * `strcmp_()`
+    * `strcmp_T()`
     * `strcpy_T()`
     * `strlen_T()`
     * `strncat_T()`
@@ -60,7 +60,8 @@ automatically:
 * [src/fstrings/FCString.h](src/fstrings/FCString.h)
     * `class FCString`
     * An object that can hold either a C-string (`const char*`) or an
-      F-string (`const __FlashStringHelper*`).
+      F-string (`const __FlashStringHelper*`), and a type discrimination tag
+      that allows the client code to determine the type at runtime.
 * [src/fstrings/FlashString.h](src/fstrings/FlashString.h)
     * [src/fstrings/README.md](src/fstrings/README.md)
     * `class FlashString`
@@ -98,16 +99,15 @@ automatically:
 
 * [src/print_str/PrintStr.h](src/print_str/PrintStr.h)
     * [src/print_str/README.md](src/print_str/README.md)
-        * Provides classes that implement the `Print` interface so that
-          values can be printed into in-memory buffers. The string can then
-          be extracted as a normal c-string using `const char*
-          PrintStr::cstr()`.
-        * Alternative to the Arduino `String` class to avoid or reduce heap
-          fragmentation.
+    * Provides classes that implement the `Print` interface so that
+        values can be printed into in-memory buffers. The string can then
+        be extracted as a normal c-string using `const char*
+        PrintStr::cstr()`.
+    * Alternative to the Arduino `String` class to avoid or reduce heap
+        fragmentation.
     * `class PrintStrBase`
     * `class PrintStr<uint16_t SIZE>` (buffer on stack)
     * `class PrintStrN(uint16_t size)` (buffer on heap)
-
 
 **Print Utilities**
 
@@ -128,9 +128,9 @@ automatically:
         * Does not use floating point operations.
 * [src/print_utils/printfTo.h](src/print_utils/printfTo.h)
     * [src/print_utils/README.md](src/print_utils/README.md)
-        * Provides a primitive `printf()` functionality to an instance of
-          `Print` (e.g. `Serial`) for those Arduino boards without a
-          `Print.printf()` function.
+    * Provides a primitive `printf()` functionality to an instance of
+      `Print` (e.g. `Serial`) for those Arduino boards without a
+      `Print.printf()` function.
     * `void printfTo(Print& printer, const char* fmt, ...)`
 * [src/print_utils/printReplaceTo.h](src/print_utils/printReplaceTo.h)
     * Print a string while replacing a character with another character or
@@ -145,7 +145,7 @@ automatically:
     * `void printReplaceStringTo(
       Print& printer, const __FlashStringHelper* src, char oldChar,
       const char* newString)`
-* [src/print_utils/printIntAsFlost.h](src/print_utils/printIntAsFloat.h)
+* [src/print_utils/printIntAsFloat.h](src/print_utils/printIntAsFloat.h)
     * Print `uint16_t` and `uint32_t` as a floating point number with 3 decimal
       places after conceptually dividing by 1000.
     * No floating point operations are used.
@@ -154,9 +154,8 @@ automatically:
 
 * [src/timing_stats/TimingStats.h](src/timing_stats/TimingStats.h)
     * [src/timing_stats/README.md](src/timing_stats/README.md)
-        * Helper class to collect data (often durations in milliseconds) and
-          then print out various statistics such as min, max, average, and
-          count.
+    * Helper class to collect data (often durations in milliseconds) and
+      then print out various statistics such as min, max, average, and count.
     * `class TimingStats`
 * [src/timing_stats/GenericStats.h](src/timing_stats/GenericStats.h)
     * Same as `TimingStats` but templatized to support generic type `T`

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AceCommon
-version=1.6.1
+version=1.6.2
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=Small low-level classes and functions for Arduino: incrementMod(), decToBcd(). strcmp_PP(), PrintStr<N>, PrintStrN, printPad{N}To(), printIntAsFloat(), TimingStats, formUrlEncode(), FCString, KString, hashDjb2(), binarySearch(), linearSearch(), isSorted(), reverse(), and so on.

--- a/src/AceCommon.h
+++ b/src/AceCommon.h
@@ -49,6 +49,7 @@ SOFTWARE.
 #include "fstrings/FCString.h"
 #include "fstrings/FlashString.h"
 #include "kstrings/KString.h"
+#include "tstrings/tstrings.h"
 #include "cstrings/copyReplace.h"
 
 #include "print_str/PrintStr.h"

--- a/src/AceCommon.h
+++ b/src/AceCommon.h
@@ -73,7 +73,7 @@ SOFTWARE.
 #include "algorithms/reverse.h"
 
 // Version format: "xx.yy.zz" => xxyyzz (without leading 0)
-#define ACE_COMMON_VERSION 10601
-#define ACE_COMMON_VERSION_STRING "1.6.1"
+#define ACE_COMMON_VERSION 10602
+#define ACE_COMMON_VERSION_STRING "1.6.2"
 
 #endif

--- a/src/print_str/PrintStr.h
+++ b/src/print_str/PrintStr.h
@@ -101,7 +101,9 @@ class PrintStrBase: public Print {
      * platform fixed this in v2.0.3 on 2022-05-04. I think we can finally
      * assume that most platforms implement a virtual flush() and apply the
      * `override` keyword here, which also fixes the compiler warnings in
-     * EpoxyDuino.
+     * EpoxyDuino. Unfortunately, it seems that we must still make an exception
+     * for ESP32 on PLATFORMIO which seems to be stuck using a version of the
+     * ESP32 core before v2.0.3.
      *
      * The only platform that is officially supported by AceCommon where the
      * `override` will cause problems is the
@@ -122,7 +124,7 @@ class PrintStrBase: public Print {
       || defined(ARDUINO_AVR_ATTINYX61) \
       || defined(ARDUINO_AVR_ATTINYX7) \
       || defined(ARDUINO_AVR_ATTINYX8) \
-      || (defined(ARDUINO_ARCH_ESP32) && defined(PLATFORMIO)) // hack because PIO is on espresif32 platform <v2.0.3
+      || (defined(ARDUINO_ARCH_ESP32) && defined(PLATFORMIO))
     void flush() {
   #else
     void flush() override {
@@ -187,7 +189,7 @@ class PrintStrBase: public Print {
      * the pointer from the last element of this object (i.e. &index_), and
      * thereby saving some memory.
      *
-     * But I am not convinced that I have the knowledge do that properly
+     * But I am not convinced that I have the knowledge to do that properly
      * without triggering UB (undefined behavior) in the C++ language. Do I
      * define buf_[0] here and will it point exactly where actualBuf_[] is
      * allocated? Or do I use [&PrintStrBase + sizeof(PrintStrBase)] to

--- a/src/print_str/PrintStr.h
+++ b/src/print_str/PrintStr.h
@@ -121,7 +121,8 @@ class PrintStrBase: public Print {
       || defined(ARDUINO_AVR_ATTINYX5) \
       || defined(ARDUINO_AVR_ATTINYX61) \
       || defined(ARDUINO_AVR_ATTINYX7) \
-      || defined(ARDUINO_AVR_ATTINYX8)
+      || defined(ARDUINO_AVR_ATTINYX8) \
+      || (defined(ARDUINO_ARCH_ESP32) && defined(PLATFORMIO)) // hack because PIO is on espresif32 platform <v2.0.3
     void flush() {
   #else
     void flush() override {

--- a/src/tstrings/tstrings.h
+++ b/src/tstrings/tstrings.h
@@ -1,0 +1,120 @@
+/*
+MIT License
+
+Copyright (c) 2023 Brian T. Park
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/**
+ * @file tstrings.h
+ *
+ * This file constains selected overloaded functions which act as a thin layer
+ * of indirection to their equivalent functions in the `<strings.h>` C library.
+ * The overloaded functions take either a `const char*` or a `const
+ * __FlashStringHelper*`. This allows template code to be written which is
+ * agnostic to whether the source string is in regular memory or flash memory.
+ * The compiler will select the correct implementation automatically at
+ * compile-time.
+ *
+ * Ideally all functions included in `<pgmspace.h>` that end in the `_P` suffix
+ * would be included here. But I don't have infinite time, so this currently
+ * includes only the most popular ones, or the ones that are needed for my own
+ * libraries. Additional functions can be added incrementally.
+ */
+
+#ifndef ACE_COMMON_TSTRINGS_H
+#define ACE_COMMON_TSTRINGS_H
+
+#include <string.h>
+#include <Arduino.h> // xxx_P()
+
+class __FlashStringHelper;
+
+namespace ace_common {
+
+// Functions are ordered alphabetically for ease of maintenance.
+
+inline char* strcat_T(char* dest, const char* src) {
+  return strcat(dest, src);
+}
+inline char* strcat_T(char* dest, const __FlashStringHelper* src) {
+  return strcat_P(dest, (const char*) src);
+}
+
+inline const char* strchr_T(const char* s, int c) {
+  return strchr(s, c);
+}
+inline const char* strchr_T(const __FlashStringHelper* s, int c) {
+  return strchr_P((const char*) s, c);
+}
+
+inline int strcmp_T(const char* s1, const char* s2) {
+  return strcmp(s1, s2);
+}
+inline int strcmp_T(const char* s1, const __FlashStringHelper* s2) {
+  return strcmp_P(s1, (const char*) s2);
+}
+
+inline char* strcpy_T(char* dest, const char* src) {
+  return strcpy(dest, src);
+}
+inline char* strcpy_T(char* dest, const __FlashStringHelper* src) {
+  return strcpy_P(dest, (const char*) src);
+}
+
+inline size_t strlen_T(const char* s) {
+  return strlen(s);
+}
+inline size_t strlen_T(const __FlashStringHelper* s) {
+  return strlen_P((const char*) s);
+}
+
+inline char* strncat_T(char* dest, const char* src, size_t n) {
+  return strncat(dest, src, n);
+}
+inline char* strncat_T(char* dest, const __FlashStringHelper* src, size_t n) {
+  return strncat_P(dest, (const char*) src, n);
+}
+
+inline int strncmp_T(const char* s1, const char* s2, size_t n) {
+  return strncmp(s1, s2, n);
+}
+inline int strncmp_T(const char* s1, const __FlashStringHelper* s2, size_t n) {
+  return strncmp_P(s1, (const char*) s2, n);
+}
+
+inline char* strncpy_T(char* dest, const char* src, size_t n) {
+  return strncpy(dest, src, n);
+}
+inline char* strncpy_T(char* dest, const __FlashStringHelper* src, size_t n) {
+  return strncpy_P(dest, (const char*) src, n);
+}
+
+inline const char* strrchr_T(const char* s, int c) {
+  return strrchr(s, c);
+}
+inline const char* strrchr_T(const __FlashStringHelper* s, int c) {
+  // ESP8266 and ESP32 don't provide strrch_P(), but AceCommon/pstrings.h does.
+  return strrchr_P((const char*) s, c);
+}
+
+}
+
+#endif

--- a/tests/TStringTest/Makefile
+++ b/tests/TStringTest/Makefile
@@ -1,0 +1,6 @@
+# See https://github.com/bxparks/EpoxyDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+
+APP_NAME := TStringTest
+ARDUINO_LIBS := AUnit AceCommon
+include ../../../EpoxyDuino/EpoxyDuino.mk

--- a/tests/TStringTest/TStringTest.ino
+++ b/tests/TStringTest/TStringTest.ino
@@ -1,0 +1,116 @@
+#line 2 "TStringTest.ino"
+
+#include <AceCommon.h>
+#include <AUnitVerbose.h>
+
+using namespace aunit;
+using namespace ace_common;
+
+test(strcat) {
+  char st[10] = "01";
+  const char s[] = "abc";
+  strcat_T(st, s);
+  assertEqual("01abc", st);
+
+  char ft[10] = "12";
+  const __FlashStringHelper* const f = F("abc");
+  strcat_T(ft, f);
+  assertEqual("12abc", ft);
+}
+
+test(strchr) {
+  const char s[] = "abc";
+  assertEqual((void*) (s + 1), strchr_T(s, 'b'));
+
+  const __FlashStringHelper* const f = F("abc");
+  assertEqual((void*) ((const char*)f + 1), strchr_T(f, 'b'));
+}
+
+test(strcmp) {
+  const char s[] = "abc";
+  assertMore(strcmp_T("abcd", s), 0);
+
+  const __FlashStringHelper* const f = F("abc");
+  assertMore(strcmp_T("abcd", f), 0);
+}
+
+test(strcpy) {
+  char st[10];
+  const char s[] = "abc";
+  strcpy_T(st, s);
+  assertEqual(st, "abc");
+
+  char ft[10];
+  const __FlashStringHelper* const f = F("abc");
+  strcpy_T(ft, f);
+  assertEqual("abc", ft);
+}
+
+test(strlen) {
+  const char s[] = "abc";
+  assertEqual((size_t)3, strlen_T(s));
+
+  const __FlashStringHelper* const f = F("abc");
+  assertEqual((size_t)3, strlen_T(f));
+}
+
+test(strncat) {
+  char st[10] = "01";
+  const char s[] = "abc";
+  strncat_T(st, s, 2);
+  assertEqual("01ab", st);
+
+  char ft[10] = "12";
+  const __FlashStringHelper* const f = F("abc");
+  strncat_T(ft, f, 2);
+  assertEqual("12ab", ft);
+}
+
+test(strncmp) {
+  const char s[] = "abc";
+  assertEqual(strncmp_T("abcd", s, 3), 0);
+
+  const __FlashStringHelper* const f = F("abc");
+  assertEqual(strncmp_T("abcd", f, 3), 0);
+}
+
+test(strncpy) {
+  char st[10];
+  const char s[] = "abc";
+  strncpy_T(st, s, 2);
+  st[2] = '\0';
+  assertEqual(st, "ab");
+
+  char ft[10];
+  const __FlashStringHelper* const f = F("abc");
+  strncpy_T(ft, f, 2);
+  ft[2] = '\0';
+  assertEqual("ab", ft);
+}
+
+test(strrchr) {
+  const char s[] = "abcd";
+  assertEqual((void*) (s + 2), strrchr_T(s, 'c'));
+
+  const __FlashStringHelper* const f = F("abcd");
+  assertEqual((void*) ((const char*)f + 2), strrchr_T(f, 'c'));
+}
+
+// ---------------------------------------------------------------------------
+
+void setup() {
+#if ! defined(EPOXY_DUINO)
+  delay(1000); // some boards reboot twice
+#endif
+
+  Serial.begin(115200);
+  while (!Serial); // Leonardo/Micro
+
+#if defined(EPOXY_DUINO)
+  Serial.setLineModeUnix();
+#endif
+}
+
+void loop() {
+  TestRunner::run();
+}


### PR DESCRIPTION
* 1.6.2 (2023-06-25)
    * Add `tstrings.h` which adds various `strxxx_T()` overloaded functions
      which take either a `const char*` or a `const __FlashStringHelper*`
      parameter.
        * Allows writing C++ template code which is agnostic to whether the
          string argument is in normal memory or flash memory. The compiler will
          select the specific implementation automatically at compile-time.
    * `PrintStr.h`
        * Add special exception for ESP32 on PlatformIO which seems to be
          stuck using the ESP32 Core from 1.x, which means that its
          `Print::flush()` is non-virtual instead of virtual (fixed in v2.0.3).
        * See [PR#28](https://github.com/bxparks/AceCommon/pull/28).
